### PR TITLE
Drop composer.json MW version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
 	"require": {
 		"php": ">=5.6",
 		"composer/installers": "^1.0.1",
-		"mediawiki/mediawiki": ">=1.27.0",
 		"mediawiki/mw-extension-registry-helper": "^1.0",
 		"mediawiki/scss": "^1.0"
 	},


### PR DESCRIPTION
In favor of the skin.json one

Fixes https://github.com/ProfessionalWiki/Bootstrap/issues/14