### PR TITLE
Revert "Drop composer.json MW version constraint"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
 	"require": {
 		"php": ">=5.6",
 		"composer/installers": "^1.0.1",
+		"mediawiki/mediawiki": ">=1.27.0",
 		"mediawiki/mw-extension-registry-helper": "^1.0",
 		"mediawiki/scss": "^1.0"
 	},


### PR DESCRIPTION
Reverts ProfessionalWiki/Bootstrap#15

As per https://github.com/ProfessionalWiki/Bootstrap/issues/14#issuecomment-609461068