### PR TITLE
Drop install time MW check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
 	"require": {
 		"php": ">=5.6",
 		"composer/installers": "^1.0.1",
-		"mediawiki/mediawiki": ">=1.27.0",
 		"mediawiki/scss": "~2.0"
 	},
 	"autoload": {


### PR DESCRIPTION
The check only has a lower bound, so only prevents a too new
boostrap from being installed. Since 4.x never supported MW
below 1.27 anyway, removing this check should not affect anyone.

At least if we assume people using older versions of Bootstrap
and MW do not use an unrestricted version of Bootstrap, ie "*".

Fixes https://github.com/ProfessionalWiki/Bootstrap/issues/14
Obsoletes https://github.com/ProfessionalWiki/Bootstrap/pull/17