### PR TITLE
Bump MW requirements to >= 1.29

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,7 @@
 	"descriptionmsg": "bootstrap-desc",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.27.0"
+		"MediaWiki": ">= 1.29.0"
 	},
 	"AutoloadNamespaces": {
 		"Bootstrap\\": "src/",


### PR DESCRIPTION
manifest_version 2 didn't exist till MW 1.29, so this definitely cannot be installed on MW 1.27.0