### PR TITLE
Initial changes for 5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,26 +14,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_35'
-            php: 7.4
-          - mw: 'REL1_37'
-            php: 7.4
-          - mw: 'REL1_37'
+          - mw: 'REL1_39'
             php: 8.0
-          - mw: 'REL1_37'
-            php: 8.1
-          - mw: 'REL1_38'
-            php: 7.4
-          - mw: 'REL1_38'
-            php: 8.0
-          - mw: 'REL1_38'
+          - mw: 'REL1_40'
             php: 8.1
           - mw: 'master'
-            php: 7.4
-          - mw: 'master'
-            php: 8.0
-          - mw: 'master'
             php: 8.1
+          - mw: 'master'
+            php: 8.2
 
     runs-on: ubuntu-latest
 
@@ -51,7 +39,7 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             mediawiki
@@ -60,7 +48,7 @@ jobs:
           key: mw_${{ matrix.mw }}-php${{ matrix.php }}
 
       - name: Cache Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache
           key: composer-php${{ matrix.php }}

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This version of the extension provides Bootstrap 4.6.2 and Popper 1.16.1.
 
 ## Requirements
 
-- PHP 5.6 or later
-- MediaWiki 1.29 or later
+- PHP 7.4.3 or later
+- MediaWiki 1.35 or later
 
 ## Installation
 
@@ -27,7 +27,7 @@ take care of that.
 
 1. On a command line go to your MediaWiki installation directory and run these two commands
    ```
-   COMPOSER=composer.local.json composer require --no-update mediawiki/bootstrap:~4.0
+   COMPOSER=composer.local.json composer require --no-update mediawiki/bootstrap:~5.0
    ```
    ```
    composer update mediawiki/bootstrap --no-dev -o

--- a/composer.json
+++ b/composer.json
@@ -35,14 +35,14 @@
 		"rss": "https://github.com/cmln/mw-bootstrap/releases.atom"
 	},
 	"require": {
-		"php": ">=7.4.3",
+		"php": ">=8.0",
 		"composer/installers": "^2|^1.0.1",
-		"mediawiki/scss": "~2.0"
+		"mediawiki/scss": "4.x-dev"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "39.0.0",
 		"mediawiki/mediawiki-phan-config": "0.11.1",
-		"php": ">=7.4.3"
+		"php": ">=8.0.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -35,14 +35,14 @@
 		"rss": "https://github.com/cmln/mw-bootstrap/releases.atom"
 	},
 	"require": {
-		"php": ">=5.6",
+		"php": ">=7.4.3",
 		"composer/installers": "^2|^1.0.1",
 		"mediawiki/scss": "~2.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "39.0.0",
 		"mediawiki/mediawiki-phan-config": "0.11.1",
-		"php": ">=7.2"
+		"php": ">=7.4.3"
 	},
 	"autoload": {
 		"psr-4": {
@@ -58,7 +58,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "4.x-dev"
+			"dev-master": "5.x-dev"
 		}
 	},
 	"config": {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,8 +4,8 @@
 
 Under development.
 
-* Raised minimum MediaWiki version from 1.29 to 1.35
-* Raised minimum PHP version from 5.6 to 7.4.3
+* Raised minimum MediaWiki version from 1.29 to 1.39
+* Raised minimum PHP version from 5.6 to 8.0
 
 ### MediaWiki Bootstrap 4.6.1
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,12 @@
 ## Release Notes
 
+### MediaWiki Bootstrap 5.0.0
+
+Under development.
+
+* Raised minimum MediaWiki version from 1.29 to 1.35
+* Raised minimum PHP version from 5.6 to 7.4.3
+
 ### MediaWiki Bootstrap 4.6.1
 
 Released on June 4, 2023.

--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,7 @@
 	"descriptionmsg": "bootstrap-desc",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.35.0"
+		"MediaWiki": ">= 1.39.0"
 	},
 	"AutoloadNamespaces": {
 		"Bootstrap\\": "src/"

--- a/extension.json
+++ b/extension.json
@@ -14,7 +14,9 @@
 		"MediaWiki": ">= 1.35.0"
 	},
 	"AutoloadNamespaces": {
-		"Bootstrap\\": "src/",
+		"Bootstrap\\": "src/"
+	},
+	"TestAutoloadNamespaces": {
 		"Bootstrap\\Tests\\": "tests/phpunit/"
 	},
 	"ResourceFileModulePaths": {

--- a/extension.json
+++ b/extension.json
@@ -6,12 +6,12 @@
 		"[https://professional.wiki/ Professional.Wiki]",
 		"James Hong Kong"
 	],
-	"version": "4.6.1",
+	"version": "5.0.0-dev",
 	"url": "https://www.mediawiki.org/wiki/Extension:Bootstrap",
 	"descriptionmsg": "bootstrap-desc",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.29.0"
+		"MediaWiki": ">= 1.35.0"
 	},
 	"AutoloadNamespaces": {
 		"Bootstrap\\": "src/",


### PR DESCRIPTION
* Raised minimum MediaWiki version from 1.29 to 1.39
* Raised minimum PHP version from 5.6 to 8.0