### PR TITLE
Fix PHPUnit invocation for MW master compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,5 +80,21 @@ jobs:
       - name: Composer update
         run: composer update
 
-      - name: Run PHPUnit
+      # "master" currently tracks MW >= 1.46, where tests/phpunit/phpunit.php
+      # was removed. Once REL1_46 lands in the matrix, it needs the master
+      # invocation below as well.
+      - name: Run PHPUnit (MW < master)
+        if: matrix.mw != 'master'
         run: php tests/phpunit/phpunit.php -c extensions/Bootstrap/
+
+      - name: Run PHPUnit (MW master)
+        if: matrix.mw == 'master'
+        run: |
+          # TODO: phpunit.xml.template is export-ignored from GitHub's tarball
+          # archive, so we fetch it separately. Remove this once installWiki.sh
+          # switches to `git clone`, or MW drops the export-ignore.
+          if [ ! -f phpunit.xml.template ]; then
+            wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
+          fi
+          composer phpunit:config
+          vendor/bin/phpunit -c extensions/Bootstrap/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,4 +97,4 @@ jobs:
             wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
           fi
           composer phpunit:config
-          vendor/bin/phpunit -c extensions/Bootstrap/
+          vendor/bin/phpunit --group extension-bootstrap


### PR DESCRIPTION
## Summary
- MW master removed `tests/phpunit/phpunit.php` along with `suite.xml` and its dedicated bootstrap ([T395470](https://phabricator.wikimedia.org/T395470), Gerrit [I03f0b4ec](https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1233741), MW 1.46-wmf.14). Consumers must now use `composer phpunit` / `vendor/bin/phpunit`. This caused the `MW master` jobs to fail with `Could not open input file: tests/phpunit/phpunit.php`.
- Branch on the matrix entry: REL1_43 → REL1_45 keep the existing `php tests/phpunit/phpunit.php -c extensions/Bootstrap/` invocation; master generates `phpunit.xml` from the upstream template and runs `vendor/bin/phpunit --group extension-bootstrap`.
- The `--group` filter (vs. `-c extensions/Bootstrap/`) is required on master because `-c` overrides the generated config, including its `bootstrap="tests/phpunit/bootstrap.php"` attribute. Without that bootstrap, MW globals like `$wgResourceModules` are never defined and `BootstrapManagerTest` errors out.
- Mirrors the pattern applied to [ProfessionalWiki/chameleon#482](https://github.com/ProfessionalWiki/chameleon/pull/482).

## Test plan
- [x] CI passes on REL1_43, REL1_44, REL1_45, master/PHP 8.4, master/PHP 8.5 (14 tests, 19 assertions on master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)