### PR TITLE
Release 6.0.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,7 +2,7 @@
 
 ### MediaWiki Bootstrap 6.0.0
 
-Under development.
+Released on May 19, 2026.
 
 * Upgraded Bootstrap from 4.6.2 to 5.3.8 (thanks @malberts)
 * Raised minimum MediaWiki version from 1.39 to 1.43

--- a/extension.json
+++ b/extension.json
@@ -4,7 +4,8 @@
 	"author": [
 		"[https://www.mediawiki.org/wiki/User:F.trott Stephan Gambke]",
 		"[https://professional.wiki/ Professional Wiki]",
-		"James Hong Kong"
+		"James Hong Kong",
+		"Morne Alberts"
 	],
 	"version": "6.0.0",
 	"url": "https://www.mediawiki.org/wiki/Extension:Bootstrap",

--- a/extension.json
+++ b/extension.json
@@ -6,7 +6,7 @@
 		"[https://professional.wiki/ Professional Wiki]",
 		"James Hong Kong"
 	],
-	"version": "6.0.0-beta",
+	"version": "6.0.0",
 	"url": "https://www.mediawiki.org/wiki/Extension:Bootstrap",
 	"descriptionmsg": "bootstrap-desc",
 	"license-name": "GPL-3.0-or-later",

--- a/src/Hooks/SetupAfterCache.php
+++ b/src/Hooks/SetupAfterCache.php
@@ -109,7 +109,7 @@ class SetupAfterCache {
 				'localBasePath'  => $localBasePath . '/js',
 				'remoteBasePath' => $remoteBasePath . '/js',
 				'es6' => true,
-				'scripts'=> [],
+				'scripts' => [],
 			],
 			array_key_exists( 'ext.bootstrap.scripts', $GLOBALS[ 'wgResourceModules' ] ) ?
 				$GLOBALS[ 'wgResourceModules' ][ 'ext.bootstrap.scripts' ] : []


### PR DESCRIPTION
Finalizes the **6.0.0** stable release.

This release ships the Bootstrap 5.3.8 upgrade (from 4.6.2) along with the raised minimum requirements. No functional or library changes are introduced here — this PR is purely release preparation:

- `extension.json`: version `6.0.0-beta` → `6.0.0`
- `docs/release-notes.md`: 6.0.0 entry finalized (`Under development.` → `Released on May 19, 2026.`), matching the existing finalized-entry format
- `src/Hooks/SetupAfterCache.php`: one-character phpcs nit — added the missing space in `'scripts'=> []` → `'scripts' => []`

This matches the prior release-prep convention (`Prepare for release X.Y.Z`, see 5.0.0 at 46defe1).

Tagging a stable `6.0.0` lets Chameleon depend on a real `^6.0` constraint instead of `6.x-dev`. See the Bootstrap 5 tracking issue #67.
