### PR TITLE
CI: switch the install script to git clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v2
 
       - name: Cache Composer cache
         uses: actions/cache@v4
@@ -90,11 +90,5 @@ jobs:
       - name: Run PHPUnit (MW master)
         if: matrix.mw == 'master'
         run: |
-          # TODO: phpunit.xml.template is export-ignored from GitHub's tarball
-          # archive, so we fetch it separately. Remove this once installWiki.sh
-          # switches to `git clone`, or MW drops the export-ignore.
-          if [ ! -f phpunit.xml.template ]; then
-            wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
-          fi
           composer phpunit:config
           vendor/bin/phpunit --group extension-bootstrap

--- a/.github/workflows/installWiki.sh
+++ b/.github/workflows/installWiki.sh
@@ -3,10 +3,7 @@
 MW_BRANCH=$1
 EXTENSION_NAME=$2
 
-wget https://github.com/wikimedia/mediawiki/archive/$MW_BRANCH.tar.gz -nv
-
-tar -zxf $MW_BRANCH.tar.gz
-mv mediawiki-$MW_BRANCH mediawiki
+git clone --depth 1 --branch ${MW_BRANCH} https://github.com/wikimedia/mediawiki.git mediawiki
 
 cd mediawiki
 


### PR DESCRIPTION
Mirrors the equivalent change being applied to the `master` branch. `master` and `rel` are byte-identical lockstep; CI changes need to land on both.

The current matrix covers REL1_43+, none of which is in the affected range, so this isn't fixing a current breakage. It removes a latent hazard as future MediaWiki versions move through the same branch-to-tag conversion, and realises the inline TODO that already predicted dropping the `phpunit.xml.template` wget.

## Switch the install script to `git clone`

Wikimedia recently converted older MediaWiki release refs (REL1_39 through REL1_42, plus older extension/skin branches) from branches to tags. The original branch refs still exist for now, so the same names resolve as both a branch AND a tag. GitHub's archive endpoint can no longer disambiguate the bare `archive/<name>.tar.gz` URL form in that state, and returns an HTTP 300 Multiple Choices with a 105-byte body:

> the given path has multiple possibilities: #<Git::Ref:...>, #<Git::Ref:...>

Switching `installWiki.sh` to `git clone --depth 1 --branch <name>` resolves whichever ref form exists and is robust to whatever Wikimedia does with the refs next.

## Drop the redundant wget for `phpunit.xml.template`

The new-runner code path was fetching `phpunit.xml.template` from `raw.githubusercontent.com` because MediaWiki marks the file `export-ignore` in `.gitattributes`, which excludes it from `git archive` output. `git clone` does not honour `export-ignore`; the file is in the working tree after a normal checkout. With `installWiki.sh` now using `git clone`, the separate wget becomes dead code. This realises the inline TODO already noting "remove this once installWiki.sh switches to `git clone`".

## Bump the cache key

Existing wget-era cache entries lack `phpunit.xml.template` because they were populated from the archive tarball. Without a key bump, on every cache hit after merge the file would be absent and `composer phpunit:config` would fail. Bump to `-v2` so the next run produces a fresh entry from the `git clone` path, with the file included.